### PR TITLE
Add home screen widget for wellness snapshot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,5 +50,17 @@
             android:enabled="true"
             android:exported="false" />
 
+        <receiver
+            android:name=".widgets.WellnessWidgetProvider"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/wellness_widget_info" />
+        </receiver>
+
     </application>
 </manifest>

--- a/app/src/main/java/com/example/personalwellness/ui/Hydration.kt
+++ b/app/src/main/java/com/example/personalwellness/ui/Hydration.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import com.example.personalwellness.R
 import com.example.personalwellness.receivers.HydrationScheduler
 import com.example.personalwellness.utils.NotificationHelper
+import com.example.personalwellness.widgets.WellnessWidgetProvider
 import org.json.JSONArray
 import org.json.JSONObject
 import java.text.SimpleDateFormat
@@ -168,6 +169,8 @@ class Hydration : Fragment() {
             "Hydration Update",
             "You added $amount ml. Total: $currentIntake / $dailyGoal ml"
         )
+
+        WellnessWidgetProvider.refreshWidget(requireContext())
     }
 
     /** Updates progress bar and text */
@@ -250,6 +253,8 @@ class Hydration : Fragment() {
         waterHistory.addView(subtext)
 
         Toast.makeText(requireContext(), "Hydration data reset!", Toast.LENGTH_SHORT).show()
+
+        WellnessWidgetProvider.refreshWidget(requireContext())
     }
 
     /** Schedules hydration reminders */

--- a/app/src/main/java/com/example/personalwellness/ui/Mood.kt
+++ b/app/src/main/java/com/example/personalwellness/ui/Mood.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.*
 import androidx.fragment.app.Fragment
 import com.example.personalwellness.R
+import com.example.personalwellness.widgets.WellnessWidgetProvider
 import com.google.android.material.tabs.TabLayout
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import com.prolificinteractive.materialcalendarview.MaterialCalendarView
@@ -139,6 +140,7 @@ class Mood : Fragment() {
         prefs.edit().putString(moodKey, jsonArray.toString()).apply()
         resetInputs()
         loadRecentMoods()
+        WellnessWidgetProvider.refreshWidget(requireContext())
     }
 
     private fun resetInputs() {
@@ -219,6 +221,7 @@ class Mood : Fragment() {
                 prefs.edit().putString(moodKey, newArray.toString()).apply()
                 loadRecentMoods()
                 Toast.makeText(requireContext(), "Mood deleted successfully!", Toast.LENGTH_SHORT).show()
+                WellnessWidgetProvider.refreshWidget(requireContext())
             }
             .setNegativeButton("No", null)
             .show()

--- a/app/src/main/java/com/example/personalwellness/widgets/WellnessWidgetProvider.kt
+++ b/app/src/main/java/com/example/personalwellness/widgets/WellnessWidgetProvider.kt
@@ -1,0 +1,153 @@
+package com.example.personalwellness.widgets
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import android.widget.RemoteViews
+import com.example.personalwellness.MainActivity
+import com.example.personalwellness.R
+import org.json.JSONArray
+
+class WellnessWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    companion object {
+        private const val HYDRATION_PREFS = "hydration_prefs"
+        private const val HYDRATION_KEY_CURRENT = "CURRENT_INTAKE"
+        private const val HYDRATION_KEY_GOAL = "DAILY_GOAL"
+
+        private const val MOOD_PREFS = "mood_prefs"
+        private const val MOOD_KEY_DATA = "MOOD_DATA"
+
+        fun refreshWidget(context: Context) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val componentName = ComponentName(context, WellnessWidgetProvider::class.java)
+            val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+            if (appWidgetIds.isEmpty()) return
+            for (appWidgetId in appWidgetIds) {
+                updateAppWidget(context, appWidgetManager, appWidgetId)
+            }
+        }
+
+        private fun updateAppWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val views = RemoteViews(context.packageName, R.layout.widget_wellness)
+
+            val hydrationInfo = getHydrationInfo(context)
+            views.setTextViewText(R.id.widgetWaterValue, hydrationInfo.displayText)
+            views.setTextViewText(R.id.widgetWaterPercent, hydrationInfo.percentText)
+            views.setProgressBar(
+                R.id.widgetWaterProgress,
+                hydrationInfo.maxProgress,
+                hydrationInfo.currentProgress,
+                false
+            )
+
+            val moodInfo = getMoodInfo(context)
+            views.setTextViewText(R.id.widgetMoodValue, moodInfo.primaryText)
+            if (moodInfo.secondaryText.isNullOrBlank()) {
+                views.setViewVisibility(R.id.widgetMoodNote, View.GONE)
+            } else {
+                views.setViewVisibility(R.id.widgetMoodNote, View.VISIBLE)
+                views.setTextViewText(R.id.widgetMoodNote, moodInfo.secondaryText)
+            }
+
+            val intent = Intent(context, MainActivity::class.java)
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.widgetRoot, pendingIntent)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        private fun getHydrationInfo(context: Context): HydrationInfo {
+            val prefs = context.getSharedPreferences(HYDRATION_PREFS, Context.MODE_PRIVATE)
+            val current = prefs.getInt(HYDRATION_KEY_CURRENT, 0)
+            val goal = prefs.getInt(HYDRATION_KEY_GOAL, 3000)
+            val safeGoal = if (goal <= 0) 1 else goal
+            val percent = ((current.toFloat() / safeGoal) * 100).toInt().coerceIn(0, 100)
+            val displayText = context.getString(
+                R.string.widget_water_value,
+                current,
+                goal
+            )
+            val percentText = context.getString(R.string.widget_water_percent, percent)
+            return HydrationInfo(
+                displayText = displayText,
+                percentText = percentText,
+                currentProgress = percent,
+                maxProgress = 100
+            )
+        }
+
+        private fun getMoodInfo(context: Context): MoodInfo {
+            val prefs = context.getSharedPreferences(MOOD_PREFS, Context.MODE_PRIVATE)
+            val stored = prefs.getString(MOOD_KEY_DATA, "[]") ?: "[]"
+            return try {
+                val jsonArray = JSONArray(stored)
+                if (jsonArray.length() == 0) {
+                    MoodInfo(
+                        primaryText = context.getString(R.string.widget_mood_empty),
+                        secondaryText = null
+                    )
+                } else {
+                    val obj = jsonArray.getJSONObject(jsonArray.length() - 1)
+                    val mood = obj.optString(
+                        "mood",
+                        context.getString(R.string.widget_mood_empty)
+                    )
+                    val note = obj.optString("note").takeIf { it.isNotBlank() }
+                    val time = obj.optString("time")
+                    val secondaryText = buildString {
+                        note?.let { append(it) }
+                        if (time.isNotBlank()) {
+                            if (isNotEmpty()) append(" • ")
+                            append(time)
+                        }
+                    }.ifBlank { null }
+                    MoodInfo(
+                        primaryText = mood,
+                        secondaryText = secondaryText
+                    )
+                }
+            } catch (e: Exception) {
+                MoodInfo(
+                    primaryText = context.getString(R.string.widget_mood_empty),
+                    secondaryText = null
+                )
+            }
+        }
+    }
+}
+
+private data class HydrationInfo(
+    val displayText: String,
+    val percentText: String,
+    val currentProgress: Int,
+    val maxProgress: Int
+)
+
+private data class MoodInfo(
+    val primaryText: String,
+    val secondaryText: String?
+)

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/colorBackground" />
+    <corners android:radius="16dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/grayLight" />
+</shape>

--- a/app/src/main/res/layout/widget_wellness.xml
+++ b/app/src/main/res/layout/widget_wellness.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widgetRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/widget_background"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/widgetTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_title"
+        android:textColor="@color/colorTextPrimary"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widgetSubtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:text="@string/widget_subtitle"
+        android:textColor="@color/colorTextSecondary"
+        android:textSize="12sp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="12dp"
+        android:background="@color/grayLight" />
+
+    <TextView
+        android:id="@+id/widgetMoodLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_mood_label"
+        android:textAllCaps="true"
+        android:textColor="@color/colorTextSecondary"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widgetMoodValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textColor="@color/colorTextPrimary"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widgetMoodNote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textColor="@color/colorTextSecondary"
+        android:textSize="12sp"
+        android:maxLines="2"
+        android:ellipsize="end" />
+
+    <TextView
+        android:id="@+id/widgetWaterLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/widget_water_label"
+        android:textAllCaps="true"
+        android:textColor="@color/colorTextSecondary"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widgetWaterValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textColor="@color/colorTextPrimary"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <ProgressBar
+        android:id="@+id/widgetWaterProgress"
+        style="@android:style/Widget.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:progressDrawable="@android:drawable/progress_horizontal"
+        android:max="100"
+        android:progressTint="@color/colorPrimary"
+        android:minHeight="12dp" />
+
+    <TextView
+        android:id="@+id/widgetWaterPercent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textColor="@color/colorTextSecondary"
+        android:textSize="12sp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,13 @@
     <string name="notification_channel_hydration_description">Notifications to remind you to drink water regularly.</string>
     <string name="notification_hydration_title">Hydration Reminder</string>
     <string name="notification_hydration_message">Time to drink some water and stay refreshed!</string>
+
+    <!-- Widget -->
+    <string name="widget_title">Wellness Snapshot</string>
+    <string name="widget_subtitle">Quick view of your day</string>
+    <string name="widget_mood_label">Current Mood</string>
+    <string name="widget_mood_empty">No mood logged yet</string>
+    <string name="widget_water_label">Water Intake</string>
+    <string name="widget_water_value">%1$d / %2$d ml</string>
+    <string name="widget_water_percent">%1$d%% of daily goal</string>
 </resources>

--- a/app/src/main/res/xml/wellness_widget_info.xml
+++ b/app/src/main/res/xml/wellness_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/widget_wellness"
+    android:widgetCategory="home_screen"
+    android:previewImage="@mipmap/ic_launcher"
+    android:resizeMode="horizontal|vertical" />


### PR DESCRIPTION
## Summary
- add an AppWidget provider that surfaces the latest mood entry and daily hydration progress
- refresh the widget whenever mood or hydration data changes and provide supporting strings/resources
- register the widget in the manifest with layout, background, and provider metadata

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e606c975388321b948ec830f77e56f