### PR TITLE
Fix widget progress tint causing widget load failure

### DIFF
--- a/app/src/main/res/drawable/widget_progress_bar.xml
+++ b/app/src/main/res/drawable/widget_progress_bar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/grayLight" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="8dp" />
+                <solid android:color="@color/colorPrimary" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/widget_wellness.xml
+++ b/app/src/main/res/layout/widget_wellness.xml
@@ -86,9 +86,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"
-        android:progressDrawable="@android:drawable/progress_horizontal"
+        android:progressDrawable="@drawable/widget_progress_bar"
         android:max="100"
-        android:progressTint="@color/colorPrimary"
         android:minHeight="12dp" />
 
     <TextView


### PR DESCRIPTION
## Summary
- replace the widget's progress bar tint attribute with a custom drawable that is safe for RemoteViews
- add a dedicated drawable so the progress styling remains consistent without triggering "Cannot load widget"

## Testing
- ./gradlew lintVitalRelease *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e60aed098483218d3615d90b05a70c